### PR TITLE
Removes the Stage from the `package` Command

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ setup:
 build:
   stage: build
   script:
-    - serverless package --stage build
+    - serverless package
 
 .deploy_template: &deploy_definition
   stage: deploy


### PR DESCRIPTION
It doesn't need it.

[CI Skip]