### PR TITLE
Switches to Promise-Based Lambda

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: marcelocorreia/serverless:1.26.1
+image: amaysim/serverless:1.27.1
 
 stages:
   - setup
@@ -24,7 +24,7 @@ build:
 .deploy_template: &deploy_definition
   stage: deploy
   script:
-    - serverless deploy --stage $CI_ENVIRONMENT_NAME --aws-s3-accelerate
+    - serverless deploy --stage "${CI_ENVIRONMENT_NAME}" --aws-s3-accelerate
   only:
     - master
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -22,3 +22,6 @@ functions:
     environment:
       AUDIENCE: https://api.cimpress.io/
       AUTHORITY: https://cimpress.auth0.com/
+
+resources:
+  Description: The platform authorizer.


### PR DESCRIPTION
Now that we're on Node 8.x, we can take advantage of not having to use
the `callback` parameter on this kind of Lambda Function.
