### PR TITLE
Removes Api and Stage Parameters

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -18,7 +18,7 @@ Metadata:
       - lambda
       - authorizer
     HomePageUrl: https://github.com/Cimpress-MCP/Platform-Authorizer
-    SemanticVersion: 1.0.0
+    SemanticVersion: 1.0.1
     SourceCodeUrl: https://github.com/Cimpress-MCP/Platform-Authorizer
 Parameters:
   Audience:
@@ -31,12 +31,6 @@ Parameters:
     Default: https://cimpress.auth0.com/
     AllowedPattern: ^https:\/\/.+
     ConstraintDescription: Authority must be an HTTPS URL.
-  Api:
-    Description: The ID of the API which this service will protect.
-    Type: String
-  Stage:
-    Description: The name of the stage of the API which this service will protect.
-    Type: String
 Globals:
   Function:
     Runtime: nodejs8.10
@@ -47,7 +41,7 @@ Globals:
         AUDIENCE: !Ref Audience
         AUTHORITY: !Ref Authority
         # note(cosborn) Tokens are valid for the whole stage, so this doesn't need to be restrictive.
-        RESOURCE: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${Api}/${Stage}/*/*
+        RESOURCE: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:*/*/*/*
 Resources:
   Authorizer:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
There's no way to specify these without a circular dependency. The
authorizer wants the ID of the API, and the API wants the ID of the
authorizer, and round and round we go...